### PR TITLE
Refactor server route wiring + extracted session-or-bearer auth

### DIFF
--- a/internal/infrastructure/http/middleware/session_or_bearer_auth.go
+++ b/internal/infrastructure/http/middleware/session_or_bearer_auth.go
@@ -1,0 +1,25 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+)
+
+// SessionOrBearerAuth authorizes a request if either:
+//   - a valid session user is present in context (from SessionMiddleware), or
+//   - a valid Bearer token is provided (via Auth).
+//
+// If a session user is present, it is preferred over Bearer auth.
+func SessionOrBearerAuth(authToken string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if userID, ok := GetSessionUserID(r.Context()); ok && userID != "" {
+				ctx := context.WithValue(r.Context(), UserIDKey, userID)
+				next.ServeHTTP(w, r.WithContext(ctx))
+				return
+			}
+
+			Auth(authToken)(next).ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/infrastructure/http/middleware/session_or_bearer_auth_test.go
+++ b/internal/infrastructure/http/middleware/session_or_bearer_auth_test.go
@@ -1,0 +1,78 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSessionOrBearerAuth_SessionWins(t *testing.T) {
+	mw := SessionOrBearerAuth("test-token")
+
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := GetUserID(r.Context())
+		if !ok {
+			t.Fatalf("expected user id in context")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(userID))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = req.WithContext(context.WithValue(req.Context(), SessionUserIDKey, "session-user"))
+	req.Header.Set("Authorization", "Bearer wrong-token")
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if got := w.Body.String(); got != "session-user" {
+		t.Fatalf("expected session user, got %q", got)
+	}
+}
+
+func TestSessionOrBearerAuth_BearerUsedWhenNoSession(t *testing.T) {
+	mw := SessionOrBearerAuth("test-token")
+
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := GetUserID(r.Context())
+		if !ok {
+			t.Fatalf("expected user id in context")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(userID))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if got := w.Body.String(); got != "authenticated-user" {
+		t.Fatalf("expected bearer user, got %q", got)
+	}
+}
+
+func TestSessionOrBearerAuth_UnauthorizedWhenNoSessionOrBearer(t *testing.T) {
+	mw := SessionOrBearerAuth("test-token")
+
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
Closes #117.

## Summary
Refactors `internal/infrastructure/http/server/server.go` to make route wiring easier to scan and safer to change, and extracts the previously-inline “session OR Bearer” auth wrapper into a named, reusable middleware with unit tests.

## What changed
### Server route setup
- `Server.setupRoutes()` is now a short orchestration method.
- Route registration is split into focused helpers:
  - `setupRateLimiters()`
  - `setupHealthRoutes()` (`/health`, `/ready`)
  - `setupMetricsRoutes()` (`/metrics`, with optional auth)
  - `setupPageRoutes()` (`/`, `/create`, `/login`, `/logout`, `/dashboard`)
  - `setupRedirectRoutes()` (`/{shortCode}`)
  - `setupAPIRoutes()` (`/api/urls/*`)
- Handler/use-case wiring is extracted into `buildHandlers()` (still uses SQLite repos today).

### Auth extraction (no behavior change)
- Replaced the inline middleware inside `/api/urls` that preferred session cookies and otherwise fell back to Bearer auth.
- New middleware: `middleware.SessionOrBearerAuth(authToken)`
  - If a valid session user is present in context (from `SessionMiddleware`), it injects `middleware.UserIDKey` and continues.
  - Otherwise it falls back to existing `middleware.Auth(authToken)`.
- Added unit tests to lock in the precedence rules (session wins over bearer, bearer works when no session, 401 when neither).

## Why
`setupRoutes()` was doing rate limit defaults, infra endpoints, repo/use-case/handler wiring, and route registration (plus an inline auth wrapper) in one function. Splitting this keeps behavior identical while making future work (adding endpoints/auth modes, moving DB detection per #113) much easier to review and less error-prone.

## Testing
- `sqlc generate`
- `make test`
- `go build ./...`
