### PR TITLE
SQLite sqlc cleanup: remove Column1 param + stable click dates

### DIFF
--- a/internal/adapters/repository/click_repository_sqlite.go
+++ b/internal/adapters/repository/click_repository_sqlite.go
@@ -84,11 +84,8 @@ func (r *SQLiteClickRepository) GetStatsByURL(ctx context.Context, urlID int64) 
 
 	byDate := make(map[string]int64)
 	for _, row := range dateRows {
-		if row.Date != nil {
-			// SQLite returns interface{} for DATE() which needs to be converted to string
-			if dateStr, ok := row.Date.(string); ok {
-				byDate[dateStr] = row.Count
-			}
+		if row.Date != "" {
+			byDate[row.Date] = row.Count
 		}
 	}
 

--- a/internal/adapters/repository/sqlc/sqlite/querier.go
+++ b/internal/adapters/repository/sqlc/sqlite/querier.go
@@ -9,8 +9,8 @@ import (
 )
 
 type Querier interface {
-	// Parameters: created_by_filter (pass empty string to count all URLs)
-	CountURLsByCreatedBy(ctx context.Context, createdByFilter interface{}) (int64, error)
+	CountURLs(ctx context.Context) (int64, error)
+	CountURLsByCreatedBy(ctx context.Context, createdBy string) (int64, error)
 	// ============================================================================
 	// URL Queries
 	// ============================================================================
@@ -24,6 +24,7 @@ type Querier interface {
 	GetClicksByReferrerInTimeRange(ctx context.Context, arg GetClicksByReferrerInTimeRangeParams) ([]GetClicksByReferrerInTimeRangeRow, error)
 	GetTotalClickCount(ctx context.Context, urlID int64) (int64, error)
 	GetTotalClickCountInTimeRange(ctx context.Context, arg GetTotalClickCountInTimeRangeParams) (int64, error)
+	ListAllURLs(ctx context.Context, arg ListAllURLsParams) ([]Url, error)
 	ListURLs(ctx context.Context, arg ListURLsParams) ([]Url, error)
 	ListURLsByCreatedByAndTimeRange(ctx context.Context, arg ListURLsByCreatedByAndTimeRangeParams) ([]Url, error)
 	// ============================================================================

--- a/internal/adapters/repository/sqlc/sqlite/queries.sql
+++ b/internal/adapters/repository/sqlc/sqlite/queries.sql
@@ -19,7 +19,13 @@ WHERE short_code = ?;
 -- name: ListURLs :many
 SELECT id, short_code, original_url, created_at, created_by
 FROM urls
-WHERE (? = '' OR created_by = ?)
+WHERE created_by = ?
+ORDER BY created_at DESC
+LIMIT ? OFFSET ?;
+
+-- name: ListAllURLs :many
+SELECT id, short_code, original_url, created_at, created_by
+FROM urls
 ORDER BY created_at DESC
 LIMIT ? OFFSET ?;
 
@@ -31,11 +37,14 @@ WHERE created_by = ?
   AND created_at <= ?
 ORDER BY created_at DESC;
 
+-- name: CountURLs :one
+SELECT COUNT(*) as count
+FROM urls;
+
 -- name: CountURLsByCreatedBy :one
--- Parameters: created_by_filter (pass empty string to count all URLs)
 SELECT COUNT(*) as count
 FROM urls
-WHERE (sqlc.arg(created_by_filter) = '' OR created_by = sqlc.arg(created_by_filter));
+WHERE created_by = ?;
 
 -- ============================================================================
 -- Click Queries
@@ -71,7 +80,7 @@ ORDER BY count DESC
 LIMIT 10;
 
 -- name: GetClicksByDate :many
-SELECT DATE(clicked_at) as date, COUNT(*) as count
+SELECT CAST(DATE(clicked_at) AS TEXT) as date, COUNT(*) as count
 FROM clicks
 WHERE url_id = ?
 GROUP BY date

--- a/internal/adapters/repository/url_repository_sqlite.go
+++ b/internal/adapters/repository/url_repository_sqlite.go
@@ -73,12 +73,23 @@ func (r *SQLiteURLRepository) List(ctx context.Context, createdBy string, limit,
 		limit = -1 // SQLite uses -1 for no limit
 	}
 
-	results, err := r.queries.ListURLs(ctx, sqliterepo.ListURLsParams{
-		Column1:   createdBy,
-		CreatedBy: createdBy,
-		Limit:     int64(limit),
-		Offset:    int64(offset),
-	})
+	var (
+		results []sqliterepo.Url
+		err     error
+	)
+
+	if createdBy == "" {
+		results, err = r.queries.ListAllURLs(ctx, sqliterepo.ListAllURLsParams{
+			Limit:  int64(limit),
+			Offset: int64(offset),
+		})
+	} else {
+		results, err = r.queries.ListURLs(ctx, sqliterepo.ListURLsParams{
+			CreatedBy: createdBy,
+			Limit:     int64(limit),
+			Offset:    int64(offset),
+		})
+	}
 
 	if err != nil {
 		return nil, mapURLSQLError(err)
@@ -126,7 +137,16 @@ func (r *SQLiteURLRepository) ListByCreatedByAndTimeRange(ctx context.Context, c
 
 // Count returns the total count of URLs for a specific user
 func (r *SQLiteURLRepository) Count(ctx context.Context, createdBy string) (int, error) {
-	count, err := r.queries.CountURLsByCreatedBy(ctx, createdBy)
+	var (
+		count int64
+		err   error
+	)
+
+	if createdBy == "" {
+		count, err = r.queries.CountURLs(ctx)
+	} else {
+		count, err = r.queries.CountURLsByCreatedBy(ctx, createdBy)
+	}
 
 	if err != nil {
 		return 0, mapURLSQLError(err)


### PR DESCRIPTION
## Why
Issue #114 flagged that a couple SQLite sqlc queries were generating awkward Go types (extra params like `Column1` and date fields typed as `interface{}`). That forced repository-layer workarounds (manual param juggling + type assertions), making the adapter code noisier and more error-prone.

## What changed
### SQLite sqlc query updates
File: `internal/adapters/repository/sqlc/sqlite/queries.sql`
- `ListURLs` now **always** filters by a single `created_by` parameter (no conditional), eliminating the extra generated parameter.
- Added `ListAllURLs` for the explicit “no filter” case.
- Split counts into:
  - `CountURLs` (count all)
  - `CountURLsByCreatedBy` (count filtered)
  so sqlc no longer has to generate an `interface{}` arg for conditional filtering.
- `GetClicksByDate` now uses `CAST(DATE(clicked_at) AS TEXT) AS date` so sqlc generates a stable `string` date column.

### Repository simplifications
- `internal/adapters/repository/url_repository_sqlite.go`
  - Removed the `Column1` workaround.
  - `List` now dispatches to `ListAllURLs` when `createdBy == ""`, otherwise `ListURLs`.
  - `Count` now dispatches to `CountURLs` vs `CountURLsByCreatedBy`.
- `internal/adapters/repository/click_repository_sqlite.go`
  - Removed DATE() `interface{}` type assertions; it now consumes generated `string` dates directly.

### Generated code
- Regenerated SQLite sqlc output under `internal/adapters/repository/sqlc/sqlite/`.

## Acceptance criteria
- ✅ No more `Column1` params in generated SQLite params.
- ✅ No `interface{}` handling for click dates in repositories.
- ✅ Repository mapping code is simpler.

## Testing
- `sqlc generate`
- `make test`

Fixes #114
