### PR TITLE
GoDoc: add package docs + fill missing exported comments

### DIFF
--- a/cmd/migrate/doc.go
+++ b/cmd/migrate/doc.go
@@ -1,0 +1,2 @@
+// Command migrate applies mjr.wtf database migrations.
+package main

--- a/cmd/server/doc.go
+++ b/cmd/server/doc.go
@@ -1,0 +1,2 @@
+// Command server starts the mjr.wtf HTTP server.
+package main

--- a/internal/adapters/geolocation/doc.go
+++ b/internal/adapters/geolocation/doc.go
@@ -1,0 +1,2 @@
+// Package geolocation provides adapter implementations of domain geolocation services.
+package geolocation

--- a/internal/adapters/geolocation/geoip2.go
+++ b/internal/adapters/geolocation/geoip2.go
@@ -1,6 +1,3 @@
-// Package geolocation provides adapters for IP geolocation services.
-// This package implements the geolocation.LookupService interface defined
-// in the domain layer using MaxMind GeoIP2 databases.
 package geolocation
 
 import (

--- a/internal/adapters/http/templates/layouts/doc.go
+++ b/internal/adapters/http/templates/layouts/doc.go
@@ -1,0 +1,2 @@
+// Package layouts contains templ-generated layout components shared across HTML pages.
+package layouts

--- a/internal/adapters/http/templates/pages/doc.go
+++ b/internal/adapters/http/templates/pages/doc.go
@@ -1,0 +1,2 @@
+// Package pages contains templ-generated HTML page components.
+package pages

--- a/internal/adapters/notification/doc.go
+++ b/internal/adapters/notification/doc.go
@@ -1,0 +1,2 @@
+// Package notification provides adapters for external notifications (e.g., Discord webhooks).
+package notification

--- a/internal/adapters/repository/doc.go
+++ b/internal/adapters/repository/doc.go
@@ -1,0 +1,2 @@
+// Package repository contains database-backed repository adapters for domain persistence ports.
+package repository

--- a/internal/adapters/repository/sqlc/sqlite/doc.go
+++ b/internal/adapters/repository/sqlc/sqlite/doc.go
@@ -1,0 +1,4 @@
+// Package sqliterepo contains sqlc-generated SQLite query bindings.
+//
+// The source of truth for this package is the sqlc configuration + SQL query files; do not edit generated files.
+package sqliterepo

--- a/internal/application/doc.go
+++ b/internal/application/doc.go
@@ -1,0 +1,4 @@
+// Package application contains use cases for the mjr.wtf URL shortener.
+//
+// Use cases coordinate domain logic with ports (repositories/services) and are free of transport concerns.
+package application

--- a/internal/application/redirect_url.go
+++ b/internal/application/redirect_url.go
@@ -1,5 +1,3 @@
-// Package application contains use case implementations for the mjrwtf URL shortener,
-// coordinating between domain entities and adapters.
 package application
 
 import (

--- a/internal/domain/click/doc.go
+++ b/internal/domain/click/doc.go
@@ -1,0 +1,2 @@
+// Package click contains the click analytics domain model and repository port for recording and aggregating clicks.
+package click

--- a/internal/domain/geolocation/doc.go
+++ b/internal/domain/geolocation/doc.go
@@ -1,0 +1,2 @@
+// Package geolocation defines the domain port for looking up geo metadata (e.g., country) from an IP address.
+package geolocation

--- a/internal/domain/geolocation/service.go
+++ b/internal/domain/geolocation/service.go
@@ -1,6 +1,3 @@
-// Package geolocation provides domain interfaces for IP geolocation services.
-// This package defines the port (interface) for geolocation lookup following
-// hexagonal architecture principles.
 package geolocation
 
 import "context"

--- a/internal/domain/url/doc.go
+++ b/internal/domain/url/doc.go
@@ -1,0 +1,2 @@
+// Package url contains the core URL domain model, validation rules, and repository port.
+package url

--- a/internal/infrastructure/config/doc.go
+++ b/internal/infrastructure/config/doc.go
@@ -1,0 +1,2 @@
+// Package config loads and validates mjr.wtf configuration from environment variables (and optional .env files).
+package config

--- a/internal/infrastructure/database/doc.go
+++ b/internal/infrastructure/database/doc.go
@@ -1,0 +1,2 @@
+// Package database provides database connection helpers (currently focused on SQLite DSN normalization).
+package database

--- a/internal/infrastructure/database/sqlite.go
+++ b/internal/infrastructure/database/sqlite.go
@@ -1,7 +1,3 @@
-// Package database provides database connection utilities and configuration helpers.
-//
-// Currently this package focuses on SQLite DSN normalization and recommended
-// connection pool settings.
 package database
 
 import (
@@ -10,7 +6,10 @@ import (
 )
 
 const (
-	SQLiteMaxOpenConns  = 1
+	// SQLiteMaxOpenConns is the recommended maximum number of open connections for SQLite.
+	SQLiteMaxOpenConns = 1
+
+	// SQLiteBusyTimeoutMs is the busy timeout, in milliseconds, applied via the SQLite DSN.
 	SQLiteBusyTimeoutMs = 5000
 )
 

--- a/internal/infrastructure/http/handlers/doc.go
+++ b/internal/infrastructure/http/handlers/doc.go
@@ -1,0 +1,2 @@
+// Package handlers contains HTTP handlers for the mjr.wtf JSON API and HTML endpoints.
+package handlers

--- a/internal/infrastructure/http/middleware/doc.go
+++ b/internal/infrastructure/http/middleware/doc.go
@@ -1,0 +1,2 @@
+// Package middleware contains HTTP middleware for auth, sessions, logging, recovery, security headers, metrics, and rate limiting.
+package middleware

--- a/internal/infrastructure/http/middleware/rate_limit.go
+++ b/internal/infrastructure/http/middleware/rate_limit.go
@@ -33,6 +33,7 @@ type RateLimiterMiddleware struct {
 	rl *rateLimiter
 }
 
+// NewRateLimiterMiddleware creates a per-client (IP-based) rate limiting middleware.
 func NewRateLimiterMiddleware(requestsPerMinute int, window time.Duration) *RateLimiterMiddleware {
 	return &RateLimiterMiddleware{rl: newRateLimiter(requestsPerMinute, window)}
 }
@@ -55,6 +56,7 @@ func (m *RateLimiterMiddleware) Middleware(next http.Handler) http.Handler {
 	})
 }
 
+// Shutdown stops the background cleanup goroutine for the rate limiter.
 func (m *RateLimiterMiddleware) Shutdown() {
 	m.rl.shutdown()
 }

--- a/internal/infrastructure/http/server/doc.go
+++ b/internal/infrastructure/http/server/doc.go
@@ -1,0 +1,2 @@
+// Package server wires the HTTP router, middleware stack, and application dependencies.
+package server

--- a/internal/infrastructure/http/server/server.go
+++ b/internal/infrastructure/http/server/server.go
@@ -25,9 +25,11 @@ import (
 
 const (
 	// Server timeout configurations
-	readTimeout     = 15 * time.Second
-	writeTimeout    = 15 * time.Second
-	idleTimeout     = 60 * time.Second
+	readTimeout  = 15 * time.Second
+	writeTimeout = 15 * time.Second
+	idleTimeout  = 60 * time.Second
+
+	// ShutdownTimeout is the maximum time allowed for graceful server shutdown.
 	ShutdownTimeout = 30 * time.Second
 
 	defaultRedirectRateLimitPerMinute = 120

--- a/internal/infrastructure/logging/doc.go
+++ b/internal/infrastructure/logging/doc.go
@@ -1,0 +1,2 @@
+// Package logging provides structured logging helpers using zerolog.
+package logging

--- a/internal/infrastructure/logging/logger.go
+++ b/internal/infrastructure/logging/logger.go
@@ -1,4 +1,3 @@
-// Package logging provides structured logging functionality using zerolog.
 package logging
 
 import (

--- a/internal/infrastructure/metrics/doc.go
+++ b/internal/infrastructure/metrics/doc.go
@@ -1,0 +1,2 @@
+// Package metrics provides Prometheus instrumentation and an HTTP handler for exporting metrics.
+package metrics

--- a/internal/infrastructure/metrics/metrics.go
+++ b/internal/infrastructure/metrics/metrics.go
@@ -1,5 +1,3 @@
-// Package metrics provides Prometheus metrics for the application.
-// It includes HTTP request metrics, URL tracking metrics, and Go runtime metrics.
 package metrics
 
 import (

--- a/internal/infrastructure/session/doc.go
+++ b/internal/infrastructure/session/doc.go
@@ -1,0 +1,2 @@
+// Package session provides an in-memory session store used by HTTP middleware.
+package session

--- a/internal/migrations/doc.go
+++ b/internal/migrations/doc.go
@@ -1,0 +1,2 @@
+// Package migrations embeds database migration files for use by the migrate CLI and tests.
+package migrations


### PR DESCRIPTION
Closes #141

## Why
GoDoc is the primary developer-facing documentation surface for Go projects (`go doc`, pkg.go.dev). Several packages in this repo had exported identifiers but no package-level docs, which made it harder to discover intent and the ownership boundaries across the hexagonal architecture.

## What changed
- Added a `doc.go` to each Go package under `internal/` (plus `cmd/server` and `cmd/migrate`) to provide a short 1–2 sentence package summary.
  - This keeps package documentation in a single canonical location per package and makes `go doc <pkg>` output immediately useful.
- Normalized existing inline package comments by moving them into the new `doc.go` files (no behavior changes).
- Filled a few gaps in exported identifier docs where the symbol was exported but previously undocumented:
  - `internal/infrastructure/database`: added GoDoc for `SQLiteMaxOpenConns` and `SQLiteBusyTimeoutMs`.
  - `internal/infrastructure/http/server`: documented `ShutdownTimeout`.
  - `internal/infrastructure/http/middleware`: documented `NewRateLimiterMiddleware` and `(*RateLimiterMiddleware).Shutdown`.

## Notes / constraints
- Code-generated packages are intentionally not edited:
  - `internal/adapters/repository/sqlc/sqlite` (sqlc) and `internal/adapters/http/templates/*` (templ) contain generated code. This PR adds package docs via `doc.go` in those directories but does not attempt to retrofit GoDoc onto generated exported identifiers, since those files are regenerated and should remain unchanged.

## Testing
- `sqlc generate`
- `go test ./...`
