### PR TITLE
Error-handling policy + errors.Is test assertions

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,0 +1,34 @@
+# Error handling policy
+
+This project follows idiomatic Go error handling:
+
+- Return errors, don’t panic (except in tests / truly unrecoverable programmer errors).
+- Preserve **error identity** across boundaries so callers can use `errors.Is` / `errors.As`.
+- Add **context** at abstraction boundaries without losing identity.
+
+## Domain layer (`internal/domain/...`)
+
+- Prefer **sentinel** or **typed** domain errors for validation and business rules (e.g. `url.ErrInvalidShortCode`).
+- The domain should not generally expose low-level implementation error *identity* (DB driver errors, `net/url` parse errors, etc.).
+- If helpful for debugging, domain code may include low-level error *text* while preserving the domain sentinel identity.
+  - Example policy: `fmt.Errorf("%w: %v", url.ErrInvalidOriginalURL, err)` preserves `url.ErrInvalidOriginalURL` but does not allow `errors.Is(err, <parseErr>)`.
+
+## Application & infrastructure layers (`internal/application`, `internal/infrastructure/...`)
+
+- When adding context, wrap the underlying error with `%w`:
+
+```go
+return nil, fmt.Errorf("failed to create shortened URL: %w", err)
+```
+
+This keeps the underlying identity so upstream layers/tests can use `errors.Is/As`.
+
+## Creating new errors
+
+- Use `errors.New("literal")` for constant, non-formatted errors.
+- Use `fmt.Errorf` only when formatting is required and/or when wrapping with `%w`.
+
+## Testing guidance
+
+- Prefer `errors.Is(err, want)` (or `errors.As`) over string matching.
+- String matching is reserved for cases where there is no stable sentinel/typed error to assert on (e.g. human-facing log or HTTP response bodies).

--- a/internal/application/create_url_test.go
+++ b/internal/application/create_url_test.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -224,8 +225,7 @@ func TestCreateURLUseCase_Execute(t *testing.T) {
 					t.Errorf("Execute() error = nil, wantErr %v", tt.wantErr)
 					return
 				}
-				// Check if error message contains expected error
-				if !strings.Contains(err.Error(), tt.wantErr.Error()) {
+				if !errors.Is(err, tt.wantErr) {
 					t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
 				}
 				return
@@ -313,8 +313,8 @@ func TestCreateURLUseCase_Execute_MaxRetriesExceeded(t *testing.T) {
 		return
 	}
 
-	if !strings.Contains(err.Error(), url.ErrMaxRetriesExceeded.Error()) {
-		t.Errorf("Execute() error = %v, want error containing %v", err, url.ErrMaxRetriesExceeded)
+	if !errors.Is(err, url.ErrMaxRetriesExceeded) {
+		t.Errorf("Execute() error = %v, want %v", err, url.ErrMaxRetriesExceeded)
 	}
 }
 

--- a/internal/application/delete_url_test.go
+++ b/internal/application/delete_url_test.go
@@ -3,7 +3,6 @@ package application
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -173,7 +172,7 @@ func TestDeleteURLUseCase_Execute(t *testing.T) {
 					t.Errorf("Execute() error = nil, wantErr %v", tt.wantErr)
 					return
 				}
-				if !errors.Is(err, tt.wantErr) && !strings.Contains(err.Error(), tt.wantErr.Error()) {
+				if !errors.Is(err, tt.wantErr) {
 					t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
 				}
 				return

--- a/internal/domain/url/generator_test.go
+++ b/internal/domain/url/generator_test.go
@@ -335,7 +335,7 @@ func TestGenerator_GenerateUniqueShortCode(t *testing.T) {
 		}
 
 		_, err = testGen.GenerateUniqueShortCode(context.Background())
-		if err != ErrMaxRetriesExceeded {
+		if !errors.Is(err, ErrMaxRetriesExceeded) {
 			t.Errorf("GenerateUniqueShortCode() error = %v, want %v", err, ErrMaxRetriesExceeded)
 		}
 
@@ -467,7 +467,7 @@ func TestGenerator_ShortenURL(t *testing.T) {
 					t.Errorf("ShortenURL() error = nil, wantErr %v", tt.wantErr)
 					return
 				}
-				if err != tt.wantErr && !strings.Contains(err.Error(), tt.wantErr.Error()) {
+				if !errors.Is(err, tt.wantErr) {
 					t.Errorf("ShortenURL() error = %v, wantErr %v", err, tt.wantErr)
 				}
 				return
@@ -550,7 +550,7 @@ func TestGenerator_ShortenURL_MaxRetriesExceeded(t *testing.T) {
 	gen.repository = &mockAlwaysCollisionRepo{wrapped: repo, attempts: &attempts}
 
 	_, err = gen.ShortenURL(context.Background(), "https://example.com", "user1")
-	if err != ErrMaxRetriesExceeded {
+	if !errors.Is(err, ErrMaxRetriesExceeded) {
 		t.Errorf("ShortenURL() error = %v, want %v", err, ErrMaxRetriesExceeded)
 	}
 }
@@ -568,8 +568,8 @@ func TestGenerator_ShortenURL_CreateError(t *testing.T) {
 	if err == nil {
 		t.Error("ShortenURL() expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "database error") {
-		t.Errorf("ShortenURL() error = %v, want database error", err)
+	if !errors.Is(err, repo.createErr) {
+		t.Errorf("ShortenURL() error = %v, want %v", err, repo.createErr)
 	}
 }
 

--- a/internal/domain/url/url_test.go
+++ b/internal/domain/url/url_test.go
@@ -1,7 +1,7 @@
 package url
 
 import (
-	"strings"
+	"errors"
 	"testing"
 )
 
@@ -129,7 +129,7 @@ func TestNewURL(t *testing.T) {
 					t.Errorf("NewURL() error = nil, wantErr %v", tt.wantErr)
 					return
 				}
-				if err != tt.wantErr && !strings.Contains(err.Error(), tt.wantErr.Error()) {
+				if !errors.Is(err, tt.wantErr) {
 					t.Errorf("NewURL() error = %v, wantErr %v", err, tt.wantErr)
 				}
 				return
@@ -301,6 +301,11 @@ func TestValidateOriginalURL(t *testing.T) {
 			wantErr:     ErrInvalidURLScheme,
 		},
 		{
+			name:        "URL with parse error",
+			originalURL: "http://example.com/%zz",
+			wantErr:     ErrInvalidOriginalURL,
+		},
+		{
 			name:        "URL without host",
 			originalURL: "https://",
 			wantErr:     ErrMissingURLHost,
@@ -320,7 +325,7 @@ func TestValidateOriginalURL(t *testing.T) {
 					t.Errorf("ValidateOriginalURL() error = nil, wantErr %v", tt.wantErr)
 					return
 				}
-				if err != tt.wantErr && !strings.Contains(err.Error(), tt.wantErr.Error()) {
+				if !errors.Is(err, tt.wantErr) {
 					t.Errorf("ValidateOriginalURL() error = %v, wantErr %v", err, tt.wantErr)
 				}
 				return
@@ -385,7 +390,7 @@ func TestURL_Validate(t *testing.T) {
 					t.Errorf("URL.Validate() error = nil, wantErr %v", tt.wantErr)
 					return
 				}
-				if err != tt.wantErr && !strings.Contains(err.Error(), tt.wantErr.Error()) {
+				if !errors.Is(err, tt.wantErr) {
 					t.Errorf("URL.Validate() error = %v, wantErr %v", err, tt.wantErr)
 				}
 				return


### PR DESCRIPTION
## Why
Issue #143 calls for a clear, project-wide error-handling policy and a pass over existing code/tests to ensure:
- error *identity* is preserved across boundaries where callers need to reason about failures, and
- tests use `errors.Is/As` instead of string matching when a stable sentinel/typed error exists.

This improves correctness (no false positives from substring matching), keeps behavior idiomatic, and makes future refactors safer.

## What changed
### 1) Documented an explicit error-handling policy
Added **`docs/error-handling.md`** describing the conventions used throughout the repo:
- **Domain layer (`internal/domain/...`)** returns sentinel/typed domain errors.
  - The domain should not generally expose low-level implementation error *identity* (e.g. `net/url` parse errors, driver errors).
  - When helpful, domain errors may include low-level error *text* while preserving the domain sentinel identity.
- **Application/infrastructure layers** add context at boundaries using `fmt.Errorf("...: %w", err)` so `errors.Is/As` works end-to-end.
- Prefer `errors.New` for constant error strings; use `fmt.Errorf` only for formatting and/or wrapping.

### 2) Replaced sentinel-error string matching with `errors.Is` in tests
Updated tests that previously asserted sentinel errors via `strings.Contains(err.Error(), wantErr.Error())`:
- `internal/domain/url/url_test.go`
- `internal/domain/url/generator_test.go`
- `internal/application/create_url_test.go`
- `internal/application/delete_url_test.go`

These tests now assert error identity directly via `errors.Is`, which is the intended mechanism when errors are returned directly or wrapped with `%w`.

### 3) Added coverage for the URL parse-error sentinel
`internal/domain/url/url_test.go` now includes a case that triggers an actual `url.Parse` failure (`http://example.com/%zz`) and asserts:
- `errors.Is(err, ErrInvalidOriginalURL)`

This ensures the domain sentinel identity is preserved even when extra diagnostic context is included.

## Notes / Design decisions
- The existing domain behavior in `ValidateOriginalURL` intentionally preserves the domain sentinel (`ErrInvalidOriginalURL`) while not wrapping the underlying `url.Parse` error identity (documented in the new policy). This avoids coupling domain callers to low-level error types.

## Testing
Ran locally:
```bash
sqlc generate
go test ./...
go build ./...
```

## Tracking
Closes #143
