### PR TITLE
Docs: clarify SQLite-only DATABASE_URL

### DIFF
--- a/docs-site/src/content/docs/getting-started/configuration.md
+++ b/docs-site/src/content/docs/getting-started/configuration.md
@@ -23,9 +23,17 @@ export AUTH_TOKEN=token-current
 ## Common variables
 
 - `DATABASE_URL` (required)
+  - SQLite-only: set this to a **file path** (e.g. `./database.db`).
+  - URL-form values (anything containing `://`) are rejected to avoid SQLite creating a local file literally named after the URL.
 - `SERVER_PORT` (default: 8080)
 - `BASE_URL` (default: http://localhost:8080)
 - `ALLOWED_ORIGINS` (default: *)
+
+Example:
+
+```bash
+export DATABASE_URL=./database.db
+```
 
 For the full list, see the repository README:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the SQLite database schema for the mjr.wtf URL shortener application.
 
-Note: The active Goose migrations (and sqlc config) are currently **SQLite-only**; PostgreSQL schema/migrations are not maintained in this repo yet.
+Note: The active Goose migrations (and sqlc config) are currently **SQLite-only**.
 
 ## Schema Files
 

--- a/internal/infrastructure/http/README.md
+++ b/internal/infrastructure/http/README.md
@@ -136,7 +136,7 @@ The server reads configuration from environment variables:
 ```bash
 SERVER_PORT=8080          # Port to bind to (default: 8080)
 ALLOWED_ORIGINS=*         # CORS allowed origins (default: "*" - not recommended for production)
-DATABASE_URL=...          # Database connection string
+DATABASE_URL=...          # SQLite database file path (e.g. ./database.db)
 AUTH_TOKEN=...            # API authentication token
 ```
 


### PR DESCRIPTION
## Why
Several docs still described `DATABASE_URL` generically as a “connection string” and one doc still mentioned PostgreSQL, which can mislead users into providing URL-form DSNs (e.g. `postgres://...`). The server is SQLite-only and rejects URL-form values to avoid SQLite creating a local file literally named after the URL.

## What changed
- **Docs site**: clarified that `DATABASE_URL` must be a SQLite file path and added a concrete example.
- **HTTP README**: changed the `DATABASE_URL` comment to “SQLite database file path (e.g. ./database.db)”.
- **Schema docs**: removed the remaining PostgreSQL mention from `docs/README.md`.

## Validation
- `go test ./...`
- `npm --prefix docs-site run build`
- `rg -n "Postgres|PostgreSQL|postgres://|postgresql://|sqlc/postgres|postgresrepo" .` (no matches)