### PR TITLE
docs: TUI CLI install/run examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A simple URL shortener, written in Go.
 - [API Documentation](#api-documentation)
 - [Authentication](#authentication)
 - [Configuration](#configuration)
-- [TUI CLI](docs/TUI.md)
+- [TUI CLI](#tui-cli)
 - [Database Migrations](#database-migrations)
 - [Testing](#testing)
 - [Local Development](#local-development)
@@ -414,6 +414,66 @@ LOG_LEVEL=info
 LOG_FORMAT=json
 METRICS_AUTH_ENABLED=true
 ```
+
+## TUI CLI
+
+The `mjr` binary includes an interactive terminal UI (TUI) for managing short URLs via the authenticated HTTP API.
+
+### Install / run
+
+```bash
+# Build from source (recommended while developing)
+make build-mjr
+./bin/mjr tui
+
+# Or run without building a binary
+go run ./cmd/mjr tui
+
+# Or install the CLI with Go
+go install github.com/matt-riley/mjrwtf/cmd/mjr@latest
+mjr tui
+```
+
+### Configuration
+
+The TUI reads configuration from **flags**, then **environment variables**, then a **config file**.
+
+- `MJR_BASE_URL` (e.g. `http://localhost:8080` or `https://mjr.wtf`)
+- `MJR_TOKEN` (a Bearer token; must match one of `AUTH_TOKENS` / `AUTH_TOKEN` on the server)
+
+```bash
+# Local server
+export MJR_BASE_URL=http://localhost:8080
+export MJR_TOKEN=token-current
+mjr tui
+
+# Against prod
+export MJR_BASE_URL=https://mjr.wtf
+export MJR_TOKEN=token-current
+mjr tui
+```
+
+Config file (optional): `~/.config/mjrwtf/config.yaml`
+
+```yaml
+base_url: http://localhost:8080
+token: token-current
+```
+
+### Common workflows
+
+- **List URLs** (default screen)
+- **Create**: `c`
+- **Analytics**: `a`
+- **Delete**: `d` then `Enter`/`y`
+
+### Security + troubleshooting
+
+- Prefer env vars or a config file over `--token` to avoid leaking tokens into shell history.
+- **401 Unauthorized**: check `MJR_TOKEN`/`--token` matches a configured server auth token.
+- **429 Too Many Requests**: you hit the API rate limit; wait for `Retry-After` and/or refresh less frequently.
+
+See [docs/TUI.md](docs/TUI.md) for navigation/keybindings and additional details.
 
 ## Database Migrations
 

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -1,6 +1,86 @@
-# TUI CLI: UX, navigation, and keybindings (design)
+# TUI CLI
 
-This document records the agreed UX/navigation model for the **mjr.wtf** Bubble Tea TUI.
+This document covers how to install and use the **mjr.wtf** Bubble Tea TUI, plus the agreed UX/navigation model.
+
+## Install / run
+
+The TUI is shipped as part of the `mjr` CLI.
+
+```bash
+# Build from source
+make build-mjr
+./bin/mjr tui
+
+# Or run without building a binary
+go run ./cmd/mjr tui
+
+# Or install with Go
+go install github.com/matt-riley/mjrwtf/cmd/mjr@latest
+mjr tui
+```
+
+## Configuration
+
+Configuration precedence:
+
+1. Flags
+2. Environment variables
+3. Config file
+4. Defaults
+
+### Environment variables
+
+- `MJR_BASE_URL` (default: `http://localhost:8080`)
+- `MJR_TOKEN` (required for authenticated API calls)
+
+```bash
+# Local server
+export MJR_BASE_URL=http://localhost:8080
+export MJR_TOKEN=token-current
+mjr tui
+
+# Against prod
+export MJR_BASE_URL=https://mjr.wtf
+export MJR_TOKEN=token-current
+mjr tui
+```
+
+### Config file
+
+Default search path:
+
+1. `~/.config/mjrwtf/config.yaml` (preferred)
+2. `~/.config/mjrwtf/config.toml`
+
+Example YAML:
+
+```yaml
+base_url: http://localhost:8080
+token: token-current
+```
+
+## Common workflows
+
+From the URL list (default screen):
+
+- **List / refresh**: start the app; press `r` to refresh
+- **Create**: press `c`, fill the form, submit
+- **Analytics**: select a URL then press `a`
+- **Delete**: select a URL, press `d`, then confirm with `Enter`/`y`
+
+## Security notes
+
+- Avoid passing tokens on the command line (`--token ...`) since they can be captured in shell history and process lists.
+- Prefer `MJR_TOKEN` or a config file; if you must paste a token interactively, use a technique like `read -s` in your shell.
+
+## Troubleshooting
+
+- **401 Unauthorized**: ensure your token matches one of the server’s configured `AUTH_TOKENS`/`AUTH_TOKEN`.
+- **429 Too Many Requests**: you hit the API rate limit; wait for `Retry-After` and/or refresh less frequently.
+
+## UX, navigation, and keybindings (design)
+
+This section records the agreed UX/navigation model for the **mjr.wtf** Bubble Tea TUI.
 
 ## Entrypoint
 


### PR DESCRIPTION
Closes #194

## Why
We had a Bubble Tea TUI (`mjr tui`) but the repo only linked to a design/keybindings doc and did not provide a clear, copy/paste-friendly way to install and run the client (locally or against prod), or guidance on config/env vars and common workflows.

## What changed
- **README**: added a new **TUI CLI** section (and updated the table of contents) with:
  - install/run options (`make build-mjr`, `go run`, `go install`)
  - config sources + examples for `MJR_BASE_URL` / `MJR_TOKEN`
  - optional config file example (`~/.config/mjrwtf/config.yaml`)
  - common workflows (list/create/analytics/delete)
  - security note about avoiding `--token` in shell history
  - troubleshooting for **401** and **429**
- **docs/TUI.md**: expanded to include install/run/config/workflows/troubleshooting up front, while preserving the existing UX/keybindings design section.

## Notes on distribution
At the moment, the `mjr` CLI is installable via `go install .../cmd/mjr@...` or by building from source (`make build-mjr`). It is not currently included in the GoReleaser release artifacts (which only ship `server` and `migrate`).

## Validation
- `env -u AUTH_TOKEN -u AUTH_TOKENS go test ./...`
  - (my local shell had `AUTH_TOKEN`/`AUTH_TOKENS` set, which can affect config-related tests if not unset)
