### PR TITLE
Use shared reusable workflows for CI and release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,42 +108,13 @@ jobs:
             exit 1
           fi
 
-  vet:
-    name: Vet
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Set up Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Run go vet
-        run: go vet ./...
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Set up Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Run tests (PR)
-        if: github.event_name == 'pull_request'
-        run: go test ./...
-
-      - name: Run tests with race detector (main)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: go test -race ./...
+  go-ci:
+    name: Go CI (shared)
+    uses: matt-riley/matt-riley-ci/.github/workflows/go-ci.yml@v1.3.0
+    with:
+      go-version-file: go.mod
+      run-race: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      run-vet: true
 
   lint:
     name: Lint (golangci-lint)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,31 +110,25 @@ jobs:
 
   go-ci:
     name: Go CI (shared)
-    uses: matt-riley/matt-riley-ci/.github/workflows/go-ci.yml@683da5beda5e85e646955caa9462556502f28e4c # v1.3.0
+    uses: matt-riley/matt-riley-ci/.github/workflows/go-ci.yml@48547139991729b79263d956c9b11e77c08470d5 # v1.4.0
     with:
       go-version-file: go.mod
       run-race: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       run-vet: true
 
   lint:
-    name: Lint (golangci-lint)
+    name: Lint (shared golangci-lint)
+    uses: matt-riley/matt-riley-ci/.github/workflows/go-lint.yml@48547139991729b79263d956c9b11e77c08470d5 # v1.4.0
+    with:
+      go-version-file: go.mod
+      golangci-version: v2.2.0
+      golangci-args: --timeout=5m
+      continue-on-error: true
+
+  openapi:
+    name: Validate OpenAPI spec
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Set up Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
-        with:
-          version: v2.2.0
-          args: --timeout=5m
-        continue-on-error: true      
       - name: Validate OpenAPI spec
         run: |
           npm install -g @apidevtools/swagger-cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,9 @@ jobs:
     name: Validate OpenAPI spec
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - name: Validate OpenAPI spec
         run: |
           npm install -g @apidevtools/swagger-cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
 
   go-ci:
     name: Go CI (shared)
-    uses: matt-riley/matt-riley-ci/.github/workflows/go-ci.yml@v1.3.0
+    uses: matt-riley/matt-riley-ci/.github/workflows/go-ci.yml@683da5beda5e85e646955caa9462556502f28e4c # v1.3.0
     with:
       go-version-file: go.mod
       run-race: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,39 +86,18 @@ jobs:
             exit 1
           fi
 
-  fmt:
-    name: Format (gofmt)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Set up Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Check code formatting
-        run: |
-          if [ -n "$(gofmt -l .)" ]; then
-            echo "Error: Code is not formatted with gofmt"
-            echo "Run 'go fmt ./...' locally and commit the changes"
-            gofmt -l .
-            exit 1
-          fi
-
   go-ci:
     name: Go CI (shared)
-    uses: matt-riley/matt-riley-ci/.github/workflows/go-ci.yml@48547139991729b79263d956c9b11e77c08470d5 # v1.4.0
+    uses: matt-riley/matt-riley-ci/.github/workflows/go-ci.yml@2e6d1921c0c5643c42a70bf4cd54f20c7e75b3ac # v1.5.0
     with:
       go-version-file: go.mod
       run-race: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       run-vet: true
+      run-fmt: true
 
   lint:
     name: Lint (shared golangci-lint)
-    uses: matt-riley/matt-riley-ci/.github/workflows/go-lint.yml@48547139991729b79263d956c9b11e77c08470d5 # v1.4.0
+    uses: matt-riley/matt-riley-ci/.github/workflows/go-lint.yml@2e6d1921c0c5643c42a70bf4cd54f20c7e75b3ac # v1.5.0
     with:
       go-version-file: go.mod
       golangci-version: v2.2.0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,53 +4,19 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+    inputs:
+      tag_name:
+        description: Release tag to publish (optional)
+        required: false
+        type: string
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+  docker-publish:
+    uses: matt-riley/matt-riley-ci/.github/workflows/docker-ghcr-publish.yml@049544896eb3953eaa002fe976ab28a85ee1337c # v1.6.0
+    with:
+      context: .
+      tag-name: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag_name || '' }}
+      platforms: linux/amd64,linux/arm64
+      push: true
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,12 +12,9 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run Release Please
-        # Release automation is pinned to a commit SHA for deterministic and reproducible releases.
-        # The inline comment documents the corresponding major version tag for maintainability.
-        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
-        with:
-          config-file: .release-please-config.json
-          manifest-file: release-please-manifest.json
+    uses: matt-riley/matt-riley-ci/.github/workflows/release-please.yml@v1.3.0
+    with:
+      config-file: .release-please-config.json
+      manifest-file: release-please-manifest.json
+    secrets:
+      token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   release-please:
-    uses: matt-riley/matt-riley-ci/.github/workflows/release-please.yml@v1.3.0
+    uses: matt-riley/matt-riley-ci/.github/workflows/release-please.yml@683da5beda5e85e646955caa9462556502f28e4c # v1.3.0
     with:
       config-file: .release-please-config.json
       manifest-file: release-please-manifest.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   release-please:
-    uses: matt-riley/matt-riley-ci/.github/workflows/release-please.yml@48547139991729b79263d956c9b11e77c08470d5 # v1.4.0
+    uses: matt-riley/matt-riley-ci/.github/workflows/release-please.yml@2e6d1921c0c5643c42a70bf4cd54f20c7e75b3ac # v1.5.0
     with:
       config-file: .release-please-config.json
       manifest-file: release-please-manifest.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   release-please:
-    uses: matt-riley/matt-riley-ci/.github/workflows/release-please.yml@683da5beda5e85e646955caa9462556502f28e4c # v1.3.0
+    uses: matt-riley/matt-riley-ci/.github/workflows/release-please.yml@48547139991729b79263d956c9b11e77c08470d5 # v1.4.0
     with:
       config-file: .release-please-config.json
       manifest-file: release-please-manifest.json


### PR DESCRIPTION
## What this PR changes

This PR migrates `mjrwtf` to shared reusable workflows from [`matt-riley/matt-riley-ci`](https://github.com/matt-riley/matt-riley-ci), with SHA-pinned references for workflow-policy compliance.

### Migrated to shared workflows

- **Go CI (test/vet/fmt):**
  - `matt-riley/matt-riley-ci/.github/workflows/go-ci.yml@2e6d1921c0c5643c42a70bf4cd54f20c7e75b3ac` (`v1.5.0`)
  - includes `run-fmt: true`
- **Go lint (golangci-lint):**
  - `matt-riley/matt-riley-ci/.github/workflows/go-lint.yml@2e6d1921c0c5643c42a70bf4cd54f20c7e75b3ac` (`v1.5.0`)
- **Release Please:**
  - `matt-riley/matt-riley-ci/.github/workflows/release-please.yml@2e6d1921c0c5643c42a70bf4cd54f20c7e75b3ac` (`v1.5.0`)
- **Docker publish to GHCR:**
  - `matt-riley/matt-riley-ci/.github/workflows/docker-ghcr-publish.yml@049544896eb3953eaa002fe976ab28a85ee1337c` (`v1.6.0`)

### Intentionally kept local

- workflow-policy checks
- generated-code verification
- OpenAPI validation
- build behavior
- Playwright E2E

## Review feedback addressed

- Scope now fully aligns with migration intent (`fmt`, `test`, `vet`, lint, and Docker publish are shared).
- Shared refs remain SHA-pinned to satisfy workflow-policy checks.

## Validation performed

- `bash scripts/workflow-policy-check.sh`
- `make validate-openapi`
- PR CI checks (including shared workflow jobs)
