### PR TITLE
chore: bump matt-riley-ci workflow refs to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
 
   go-ci:
     name: Go checks
-    uses: matt-riley/matt-riley-ci/.github/workflows/go-ci.yml@7fd3aefaab1ae14d063930c85b2d629280c36620 # v2
+    uses: matt-riley/matt-riley-ci/.github/workflows/go-ci.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
     with:
       go-version-file: go.mod
       run-race: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
@@ -97,7 +97,7 @@ jobs:
 
   lint:
     name: Lint (golangci-lint)
-    uses: matt-riley/matt-riley-ci/.github/workflows/go-lint.yml@7fd3aefaab1ae14d063930c85b2d629280c36620 # v2
+    uses: matt-riley/matt-riley-ci/.github/workflows/go-lint.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
     with:
       go-version-file: go.mod
       golangci-version: v2.2.0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   docker-publish:
-    uses: matt-riley/matt-riley-ci/.github/workflows/docker-ghcr-publish.yml@7fd3aefaab1ae14d063930c85b2d629280c36620 # v2
+    uses: matt-riley/matt-riley-ci/.github/workflows/docker-ghcr-publish.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
     with:
       tag-name: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.tag_name || '' }}
     secrets:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   release-please:
-    uses: matt-riley/matt-riley-ci/.github/workflows/release-please.yml@7fd3aefaab1ae14d063930c85b2d629280c36620 # v2
+    uses: matt-riley/matt-riley-ci/.github/workflows/release-please.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
     with:
       config-file: .release-please-config.json
       manifest-file: release-please-manifest.json


### PR DESCRIPTION
Bumps all matt-riley-ci reusable workflow references to the latest commit.

Old SHAs replaced: 7fd3aefaab1ae14d063930c85b2d629280c36620
New SHA: bcaf4ae43edf7d26421741424b82c842c83e55ce