### PR TITLE
fix: port to Universal CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,11 +88,10 @@ jobs:
 
   go-ci:
     name: Go checks
-    uses: matt-riley/matt-riley-ci/.github/workflows/go-ci.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
+    uses: matt-riley/matt-riley-ci/.github/workflows/ci.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
     with:
-      go-version-file: go.mod
-      run-race: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      run-vet: true
+      install: true
+      test: true
       run-fmt: true
 
   lint:

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,19 @@
+[tools]
+go = "1.26.4"
+golangci-lint = "latest"
+
+[tasks.test]
+description = "Run Go tests"
+run = "go test ./..."
+
+[tasks.vet]
+description = "Run go vet"
+run = "go vet ./..."
+
+[tasks.build]
+description = "Build"
+run = "go build ./..."
+
+[tasks.lint]
+description = "Run golangci-lint"
+run = "golangci-lint run"


### PR DESCRIPTION
Ports CI from deprecated `go-ci.yml` / `node-ci.yml` (which no longer exist in matt-riley-ci) to the Universal `ci.yml`.

- Added mise.toml with Go tasks
- Ported ci.yml to Universal CI